### PR TITLE
Use tj-actions/changed-files to extract python project

### DIFF
--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     outputs:
-      target_project: ${{ steps.changes.outputs.target_projects }}
+      target_projects: ${{ steps.changes.outputs.target_projects }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,10 +42,6 @@ jobs:
           dir_names_max_depth: 1 # ディレクトリ名の深さを指定
           files_ignore: |
             .github/**
-      - name: Debug changed files
-        run: |
-          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}"
-          echo "::debug::Changed files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}"
       - name: Get Python projects
         uses: actions/github-script@v7
         id: changes
@@ -53,10 +49,10 @@ jobs:
           script: |
             const fs = require('node:fs');
             // If target_projects input is provided, use it
-            dispatch_inputs = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
-            if (dispatch_inputs) {
+            dispatch_inputs = "${{ github.event.inputs.target_projects }}";
+            if (dispatch_inputs !== "") {
               // TODO: validate the input
-              core.setOutput('target_projects', dispatch_inputs);
+              core.setOutput('target_projects', JSON.stringify(dispatch_inputs));
             } else { // If no input is provided, get directories from changed files
               const inputs = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
               // Filter out directories that contain pyproject.toml and Makefile
@@ -77,74 +73,30 @@ jobs:
           echo "Changed directories: ${{ steps.changes.outputs.target_projects }}"
           echo "::debug::Changed directories: ${{ steps.changes.outputs.target_projects }}"
 
-  # python-lint-and-test:
-  #   needs: changed_files
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Get changed directories
-  #       id: changes
-  #       run: |
-  #         # Check if the target_dir input is provided
-  #         if [ -n "${{ github.event.inputs.target_dir }}" ]; then
-  #           echo "wd=${{ github.event.inputs.target_dir }}" >> $GITHUB_OUTPUT
-  #           echo "should_run=true" >> $GITHUB_OUTPUT
-  #           exit 0
-  #         fi
-
-  #         # Get unique directories from changed files
-  #         if [ "${{ github.event_name }}" == "pull_request" ]; then
-  #           # For PRs, compare with base branch
-  #           git fetch origin ${{ github.base_ref }}
-  #           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep '\.py$' || echo "")
-  #         else
-  #           # For pushes, compare with previous commit
-  #           CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.py$' || echo "")
-  #         fi
-  #         echo "::debug::Changed files: $CHANGED_FILES"
-
-  #         # If no Python files changed, skip tests
-  #         if [ -z "$CHANGED_FILES" ]; then
-  #           echo "No Python files changed"
-  #           echo "should_run=false" >> $GITHUB_OUTPUT
-  #           exit 0
-  #         fi
-  #         CHANGED_DIRS=$(echo "$CHANGED_FILES" | awk -F/ '{print $1}' | sort -u)
-  #         echo "Changed directories: $CHANGED_DIRS"
-
-  #         # Count how many directories were changed
-  #         DIR_COUNT=$(echo "$CHANGED_DIRS" | grep -v "^$" | wc -l)
-
-  #         if [ "$DIR_COUNT" -eq 0 ]; then
-  #           echo "No Python directories changed"
-  #           echo "should_run=false" >> $GITHUB_OUTPUT
-  #           exit 0
-  #         elif [ "$DIR_COUNT" -gt 1 ]; then
-  #           echo "::error::Changes detected in multiple directories: $CHANGED_DIRS"
-  #           echo "This workflow supports changes in only one directory at a time"
-  #           exit 1
-  #         fi
-
-  #         # Set the single directory as output
-  #         echo "wd=$(echo "$CHANGED_DIRS" | tr -d '\n')" >> $GITHUB_OUTPUT
-  #         echo "should_run=true" >> $GITHUB_OUTPUT
-  #     - name: Install uv
-  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
-  #       uses: astral-sh/setup-uv@v5
-  #       with:
-  #         enable-cache: true
-  #     - name: Install the project
-  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
-  #       run: make install
-  #       working-directory: ${{ steps.changes.outputs.wd }}
-  #     - name: Lint
-  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
-  #       run: make lint
-  #       working-directory: ${{ steps.changes.outputs.wd }}
-  #     - name: Test
-  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
-  #       run: make test
-  #       working-directory: ${{ steps.changes.outputs.wd }}
+  python-lint-and-test:
+    name: Python Lint and Test
+    needs: changed_files
+    if: ${{ needs.changed_files.outputs.target_projects != '' && toJson(fromJson(needs.changed_files.outputs.target_projects)) != '[]' }}
+    strategy:
+      matrix:
+        project: ${{ fromJson(needs.changed_files.outputs.target_projects) }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.project }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install the project
+        run: make install
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -11,8 +11,8 @@ on:
       - "**/*.py"
   workflow_dispatch:
     inputs:
-      target_dir:
-        description: "Directories to run lint and test on"
+      target_projects:
+        description: "Projects to run lint and test on"
         required: false
         default: ""
 
@@ -21,73 +21,123 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  python-lint-and-test:
+  changed_files:
+    name: Find changed files
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
+    outputs:
+      target_project: ${{ steps.changes.outputs.target_projects }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Get changed directories
-        id: changes
-        run: |
-          # Check if the target_dir input is provided
-          if [ -n "${{ github.event.inputs.target_dir }}" ]; then
-            echo "wd=${{ github.event.inputs.target_dir }}" >> $GITHUB_OUTPUT
-            echo "should_run=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Get unique directories from changed files
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PRs, compare with base branch
-            git fetch origin ${{ github.base_ref }}
-            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep '\.py$' || echo "")
-          else
-            # For pushes, compare with previous commit
-            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.py$' || echo "")
-          fi
-          echo "::debug::Changed files: $CHANGED_FILES"
-
-          # If no Python files changed, skip tests
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No Python files changed"
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          CHANGED_DIRS=$(echo "$CHANGED_FILES" | awk -F/ '{print $1}' | sort -u)
-          echo "Changed directories: $CHANGED_DIRS"
-
-          # Count how many directories were changed
-          DIR_COUNT=$(echo "$CHANGED_DIRS" | grep -v "^$" | wc -l)
-
-          if [ "$DIR_COUNT" -eq 0 ]; then
-            echo "No Python directories changed"
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ "$DIR_COUNT" -gt 1 ]; then
-            echo "::error::Changes detected in multiple directories: $CHANGED_DIRS"
-            echo "This workflow supports changes in only one directory at a time"
-            exit 1
-          fi
-
-          # Set the single directory as output
-          echo "wd=$(echo "$CHANGED_DIRS" | tr -d '\n')" >> $GITHUB_OUTPUT
-          echo "should_run=true" >> $GITHUB_OUTPUT
-      - name: Install uv
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
-        uses: astral-sh/setup-uv@v5
+        id: changed-files
+        uses: tj-actions/changed-files@6cb76d07bee4c9772c6882c06c37837bf82a04d3 # v46
         with:
-          enable-cache: true
-      - name: Install the project
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
-        run: make install
-        working-directory: ${{ steps.changes.outputs.wd }}
-      - name: Lint
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
-        run: make lint
-        working-directory: ${{ steps.changes.outputs.wd }}
-      - name: Test
-        if: ${{ steps.changes.outputs.should_run }} == 'true'
-        run: make test
-        working-directory: ${{ steps.changes.outputs.wd }}
+          matrix: true # 後続のjobでmatrixで使うために。ファイルがjson形式で出力される
+          dir_names: true # uniqueディレクトリ名を取得
+          dir_names_max_depth: 1 # ディレクトリ名の深さを指定
+          files_ignore: |
+            .github/**
+      - name: Get Python projects
+        uses: actions/github-script@v7
+        id: changes
+        with:
+          script: |
+            const fs = require('node:fs');
+            // If target_projects input is provided, use it
+            if (${{ github.event.inputs.target_projects }}) {
+              core.setOutput('target_projects', ${{ github.event.inputs.target_projects }});
+            } else { // If no input is provided, get directories from changed files
+              const inputs = JSON.parse(${{ steps.changed-files.outputs.all_changed_and_modified_files }});
+              // Filter out directories that contain pyproject.toml and Makefile
+              const paths = inputs.filter(path => {
+                if (fs.statSync(path).isDirectory()) {
+                  if (
+                    fs.existsSync(`${path}/pyproject.toml`)
+                    && fs.existsSync(`${path}/Makefile`)
+                  )
+                  return true;
+                }
+              });
+              core.setOutput('target_projects', JSON.stringify(paths));
+            }
+      - name: Print changed directories
+        run: |
+          echo "Changed directories: ${{ steps.changes.outputs.target_projects }}"
+          echo "::debug::Changed directories: ${{ steps.changes.outputs.target_projects }}"
+
+  # python-lint-and-test:
+  #   needs: changed_files
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Get changed directories
+  #       id: changes
+  #       run: |
+  #         # Check if the target_dir input is provided
+  #         if [ -n "${{ github.event.inputs.target_dir }}" ]; then
+  #           echo "wd=${{ github.event.inputs.target_dir }}" >> $GITHUB_OUTPUT
+  #           echo "should_run=true" >> $GITHUB_OUTPUT
+  #           exit 0
+  #         fi
+
+  #         # Get unique directories from changed files
+  #         if [ "${{ github.event_name }}" == "pull_request" ]; then
+  #           # For PRs, compare with base branch
+  #           git fetch origin ${{ github.base_ref }}
+  #           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep '\.py$' || echo "")
+  #         else
+  #           # For pushes, compare with previous commit
+  #           CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.py$' || echo "")
+  #         fi
+  #         echo "::debug::Changed files: $CHANGED_FILES"
+
+  #         # If no Python files changed, skip tests
+  #         if [ -z "$CHANGED_FILES" ]; then
+  #           echo "No Python files changed"
+  #           echo "should_run=false" >> $GITHUB_OUTPUT
+  #           exit 0
+  #         fi
+  #         CHANGED_DIRS=$(echo "$CHANGED_FILES" | awk -F/ '{print $1}' | sort -u)
+  #         echo "Changed directories: $CHANGED_DIRS"
+
+  #         # Count how many directories were changed
+  #         DIR_COUNT=$(echo "$CHANGED_DIRS" | grep -v "^$" | wc -l)
+
+  #         if [ "$DIR_COUNT" -eq 0 ]; then
+  #           echo "No Python directories changed"
+  #           echo "should_run=false" >> $GITHUB_OUTPUT
+  #           exit 0
+  #         elif [ "$DIR_COUNT" -gt 1 ]; then
+  #           echo "::error::Changes detected in multiple directories: $CHANGED_DIRS"
+  #           echo "This workflow supports changes in only one directory at a time"
+  #           exit 1
+  #         fi
+
+  #         # Set the single directory as output
+  #         echo "wd=$(echo "$CHANGED_DIRS" | tr -d '\n')" >> $GITHUB_OUTPUT
+  #         echo "should_run=true" >> $GITHUB_OUTPUT
+  #     - name: Install uv
+  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
+  #       uses: astral-sh/setup-uv@v5
+  #       with:
+  #         enable-cache: true
+  #     - name: Install the project
+  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
+  #       run: make install
+  #       working-directory: ${{ steps.changes.outputs.wd }}
+  #     - name: Lint
+  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
+  #       run: make lint
+  #       working-directory: ${{ steps.changes.outputs.wd }}
+  #     - name: Test
+  #       if: ${{ steps.changes.outputs.should_run }} == 'true'
+  #       run: make test
+  #       working-directory: ${{ steps.changes.outputs.wd }}

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -42,6 +42,10 @@ jobs:
           dir_names_max_depth: 1 # ディレクトリ名の深さを指定
           files_ignore: |
             .github/**
+      - name: Debug changed files
+        run: |
+          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}"
+          echo "::debug::Changed files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}"
       - name: Get Python projects
         uses: actions/github-script@v7
         id: changes
@@ -49,19 +53,22 @@ jobs:
           script: |
             const fs = require('node:fs');
             // If target_projects input is provided, use it
-            if (${{ github.event.inputs.target_projects }}) {
-              core.setOutput('target_projects', ${{ github.event.inputs.target_projects }});
+            dispatch_inputs = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
+            if (dispatch_inputs) {
+              // TODO: validate the input
+              core.setOutput('target_projects', dispatch_inputs);
             } else { // If no input is provided, get directories from changed files
-              const inputs = JSON.parse(${{ steps.changed-files.outputs.all_changed_and_modified_files }});
+              const inputs = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
               // Filter out directories that contain pyproject.toml and Makefile
               const paths = inputs.filter(path => {
-                if (fs.statSync(path).isDirectory()) {
-                  if (
-                    fs.existsSync(`${path}/pyproject.toml`)
-                    && fs.existsSync(`${path}/Makefile`)
-                  )
+                if (
+                  fs.statSync(path).isDirectory()
+                  && fs.existsSync(`${path}/pyproject.toml`)
+                  && fs.existsSync(`${path}/Makefile`)
+                ) {
                   return true;
                 }
+                return false;
               });
               core.setOutput('target_projects', JSON.stringify(paths));
             }

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -21,13 +21,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changed_files:
-    name: Find changed files
+  target_projects:
+    name: Find target Projects
     permissions:
       contents: read
     runs-on: ubuntu-latest
     outputs:
-      target_projects: ${{ steps.changes.outputs.target_projects }}
+      projects: ${{ steps.get-projects.outputs.projects }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
             .github/**
       - name: Get Python projects
         uses: actions/github-script@v7
-        id: changes
+        id: get-projects
         with:
           script: |
             const fs = require('node:fs');
@@ -52,7 +52,7 @@ jobs:
             dispatch_inputs = "${{ github.event.inputs.target_projects }}";
             if (dispatch_inputs !== "") {
               // TODO: validate the input
-              core.setOutput('target_projects', JSON.stringify(dispatch_inputs));
+              core.setOutput('projects', JSON.stringify(dispatch_inputs));
             } else { // If no input is provided, get directories from changed files
               const inputs = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});
               // Filter out directories that contain pyproject.toml and Makefile
@@ -66,20 +66,20 @@ jobs:
                 }
                 return false;
               });
-              core.setOutput('target_projects', JSON.stringify(paths));
+              core.setOutput('projects', JSON.stringify(paths));
             }
       - name: Print changed directories
         run: |
-          echo "Changed directories: ${{ steps.changes.outputs.target_projects }}"
-          echo "::debug::Changed directories: ${{ steps.changes.outputs.target_projects }}"
+          echo "Changed directories: ${{ steps.get-projects.outputs.projects }}"
+          echo "::debug::Changed directories: ${{ steps.get-projects.outputs.projects }}"
 
   python-lint-and-test:
     name: Python Lint and Test
-    needs: changed_files
-    if: ${{ needs.changed_files.outputs.target_projects != '' && toJson(fromJson(needs.changed_files.outputs.target_projects)) != '[]' }}
+    needs: target_projects
+    if: ${{ needs.target_projects.outputs.projects != '' && toJson(fromJson(needs.target_projects.outputs.projects)) != '[]' }}
     strategy:
       matrix:
-        project: ${{ fromJson(needs.changed_files.outputs.target_projects) }}
+        project: ${{ fromJson(needs.target_projects.outputs.projects) }}
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.project }}

--- a/project-1/test_main.py
+++ b/project-1/test_main.py
@@ -19,7 +19,7 @@ def test_softmax():
     expected_output = np.array([0.09003057, 0.24472847, 0.66524096])
     np.testing.assert_almost_equal(softmax(x), expected_output, decimal=5)
 
-    # Test case 4: negative numbers
-    x = np.array([-1.0, -2.0, -3.0])
-    expected_output = np.array([0.66524096, 0.24472847, 0.09003057])
-    np.testing.assert_almost_equal(softmax(x), expected_output, decimal=5)
+    # # Test case 4: negative numbers
+    # x = np.array([-1.0, -2.0, -3.0])
+    # expected_output = np.array([0.66524096, 0.24472847, 0.09003057])
+    # np.testing.assert_almost_equal(softmax(x), expected_output, decimal=5)

--- a/project-1/test_main.py
+++ b/project-1/test_main.py
@@ -19,7 +19,7 @@ def test_softmax():
     expected_output = np.array([0.09003057, 0.24472847, 0.66524096])
     np.testing.assert_almost_equal(softmax(x), expected_output, decimal=5)
 
-    # # Test case 4: negative numbers
-    # x = np.array([-1.0, -2.0, -3.0])
-    # expected_output = np.array([0.66524096, 0.24472847, 0.09003057])
-    # np.testing.assert_almost_equal(softmax(x), expected_output, decimal=5)
+    # Test case 4: negative numbers
+    x = np.array([-1.0, -2.0, -3.0])
+    expected_output = np.array([0.66524096, 0.24472847, 0.09003057])
+    np.testing.assert_almost_equal(softmax(x), expected_output, decimal=5)


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Python linting and testing to improve the identification and handling of changed files and directories. The changes introduce a new job to find changed files and modify the existing job to run based on these changes.

Key changes include:

### Workflow Enhancements:
* [`.github/workflows/python-lint-test.yaml`](diffhunk://#diff-0f707253f6229432795c803f4a6199218f8424f75e3e4481d276b141f0c9b560L14-R15): Renamed `target_dir` input to `target_projects` and updated its description to reflect the change.
* [`.github/workflows/python-lint-test.yaml`](diffhunk://#diff-0f707253f6229432795c803f4a6199218f8424f75e3e4481d276b141f0c9b560L24-L93): Added a new job `changed_files` to find changed files and output the directories containing Python projects.
* [`.github/workflows/python-lint-test.yaml`](diffhunk://#diff-0f707253f6229432795c803f4a6199218f8424f75e3e4481d276b141f0c9b560L24-L93): Updated the `python-lint-and-test` job to depend on the `changed_files` job and use its output to determine the directories to run lint and test on.
* [`.github/workflows/python-lint-test.yaml`](diffhunk://#diff-0f707253f6229432795c803f4a6199218f8424f75e3e4481d276b141f0c9b560L24-L93): Removed the old logic for determining changed directories and replaced it with the new approach using the `changed_files` job.