### PR TITLE
fix(workflow): add cache-dependency-glob for UV installation

### DIFF
--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -94,6 +94,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "${{ matrix.project }}/uv.lock"
       - name: Install the project
         run: make install
       - name: Lint


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/python-lint-test.yaml` file. The change adds a `cache-dependency-glob` parameter to the `setup-uv` action to enable caching of dependencies based on the `uv.lock` file.

* [`.github/workflows/python-lint-test.yaml`](diffhunk://#diff-0f707253f6229432795c803f4a6199218f8424f75e3e4481d276b141f0c9b560R97): Added `cache-dependency-glob` parameter to `setup-uv` action to cache dependencies based on `uv.lock` file.