### PR TITLE
fix(workflow): validate and trim target_projects input in Python lint and test workflow

### DIFF
--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -51,7 +51,7 @@ jobs:
             // If target_projects input is provided, use it
             dispatch_inputs = "${{ github.event.inputs.target_projects }}";
             if (dispatch_inputs !== "") {
-              // TODO: validate the input
+              dispatch_inputs = dispatch_inputs.split(',').map(path => path.trim());
               core.setOutput('projects', JSON.stringify(dispatch_inputs));
             } else { // If no input is provided, get directories from changed files
               const inputs = JSON.parse(${{ toJSON(steps.changed-files.outputs.all_changed_and_modified_files) }});


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/python-lint-test.yaml` file to improve the handling of `target_projects` input. The most important change is the addition of a split and trim operation to ensure the input is properly formatted.

* [`.github/workflows/python-lint-test.yaml`](diffhunk://#diff-0f707253f6229432795c803f4a6199218f8424f75e3e4481d276b141f0c9b560L54-R54): Added a split and trim operation to the `dispatch_inputs` variable to ensure the input is properly formatted.